### PR TITLE
Make confirm button always visible

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "src/vaadin-confirm-dialog.html",
         "start": {
-          "line": 253,
+          "line": 216,
           "column": 6
         },
         "end": {
-          "line": 253,
+          "line": 216,
           "column": 62
         }
       },
@@ -88,9 +88,9 @@
               }
             },
             {
-              "name": "confirm",
-              "type": "boolean | null | undefined",
-              "description": "Whether to show confirm button or not.",
+              "name": "confirmText",
+              "type": "string | null | undefined",
+              "description": "Text displayed on confirm-button.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
@@ -98,30 +98,7 @@
                   "column": 12
                 },
                 "end": {
-                  "line": 110,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "notify": true,
-                  "attributeType": "Boolean"
-                }
-              },
-              "defaultValue": "false"
-            },
-            {
-              "name": "confirmText",
-              "type": "string | null | undefined",
-              "description": "Text displayed on confirm-button.\nChanging sets confirm property to true.",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 115,
-                  "column": 12
-                },
-                "end": {
-                  "line": 118,
+                  "line": 108,
                   "column": 13
                 }
               },
@@ -135,15 +112,15 @@
             {
               "name": "confirmTheme",
               "type": "string | null | undefined",
-              "description": "Theme for a confirm-button.\nChanging sets confirm property to true.",
+              "description": "Theme for a confirm-button.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 123,
+                  "line": 112,
                   "column": 12
                 },
                 "end": {
-                  "line": 126,
+                  "line": 115,
                   "column": 13
                 }
               },
@@ -161,11 +138,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 130,
+                  "line": 119,
                   "column": 12
                 },
                 "end": {
-                  "line": 135,
+                  "line": 124,
                   "column": 13
                 }
               },
@@ -180,15 +157,15 @@
             {
               "name": "rejectText",
               "type": "string | null | undefined",
-              "description": "Text displayed on cancel-button.\nChanging sets cancel property to true.",
+              "description": "Text displayed on reject-button.\nShould also set `reject` property to true.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 140,
+                  "line": 129,
                   "column": 12
                 },
                 "end": {
-                  "line": 143,
+                  "line": 132,
                   "column": 13
                 }
               },
@@ -202,15 +179,15 @@
             {
               "name": "rejectTheme",
               "type": "string | null | undefined",
-              "description": "Theme for a cancel-button.\nChanging sets cancel property to true.",
+              "description": "Theme for a reject-button.\nShould also set `reject` property to true.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 148,
+                  "line": 137,
                   "column": 12
                 },
                 "end": {
-                  "line": 151,
+                  "line": 140,
                   "column": 13
                 }
               },
@@ -228,11 +205,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 155,
+                  "line": 144,
                   "column": 12
                 },
                 "end": {
-                  "line": 160,
+                  "line": 149,
                   "column": 13
                 }
               },
@@ -247,15 +224,15 @@
             {
               "name": "cancelText",
               "type": "string | null | undefined",
-              "description": "Text displayed on cancel-button.\nChanging sets cancel property to true.",
+              "description": "Text displayed on cancel-button.\nShould also set `cancel` property to true.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 165,
+                  "line": 154,
                   "column": 12
                 },
                 "end": {
-                  "line": 168,
+                  "line": 157,
                   "column": 13
                 }
               },
@@ -269,15 +246,15 @@
             {
               "name": "cancelTheme",
               "type": "string | null | undefined",
-              "description": "Theme for a cancel-button.\nChanging sets cancel property to true.",
+              "description": "Theme for a cancel-button.\nShould also set `cancel` property to true.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 173,
+                  "line": 162,
                   "column": 12
                 },
                 "end": {
-                  "line": 176,
+                  "line": 165,
                   "column": 13
                 }
               },
@@ -296,11 +273,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 188,
+                  "line": 169,
                   "column": 8
                 },
                 "end": {
-                  "line": 192,
+                  "line": 173,
                   "column": 9
                 }
               },
@@ -316,11 +293,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 194,
+                  "line": 175,
                   "column": 8
                 },
                 "end": {
-                  "line": 200,
+                  "line": 181,
                   "column": 9
                 }
               },
@@ -335,75 +312,21 @@
               }
             },
             {
-              "name": "_confirmPropertyChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 202,
-                  "column": 8
-                },
-                "end": {
-                  "line": 206,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "confirmText"
-                },
-                {
-                  "name": "confirmTheme"
-                }
-              ],
-              "return": {
-                "type": "void"
-              }
-            },
-            {
               "name": "_confirm",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 212,
+                  "line": 187,
                   "column": 8
                 },
                 "end": {
-                  "line": 215,
+                  "line": 190,
                   "column": 9
                 }
               },
               "metadata": {},
               "params": [],
-              "return": {
-                "type": "void"
-              }
-            },
-            {
-              "name": "_cancelPropertyChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 217,
-                  "column": 8
-                },
-                "end": {
-                  "line": 221,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "cancelText"
-                },
-                {
-                  "name": "cancelTheme"
-                }
-              ],
               "return": {
                 "type": "void"
               }
@@ -414,11 +337,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 227,
+                  "line": 196,
                   "column": 8
                 },
                 "end": {
-                  "line": 230,
+                  "line": 199,
                   "column": 9
                 }
               },
@@ -429,43 +352,16 @@
               }
             },
             {
-              "name": "_rejectPropertyChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 232,
-                  "column": 8
-                },
-                "end": {
-                  "line": 236,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "rejectText"
-                },
-                {
-                  "name": "rejectTheme"
-                }
-              ],
-              "return": {
-                "type": "void"
-              }
-            },
-            {
               "name": "_reject",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 242,
+                  "line": 205,
                   "column": 8
                 },
                 "end": {
-                  "line": 245,
+                  "line": 208,
                   "column": 9
                 }
               },
@@ -490,7 +386,7 @@
               "column": 6
             },
             "end": {
-              "line": 246,
+              "line": 209,
               "column": 7
             }
           },
@@ -547,31 +443,15 @@
               "type": "string | null | undefined"
             },
             {
-              "name": "confirm",
-              "description": "Whether to show confirm button or not.",
+              "name": "confirm-text",
+              "description": "Text displayed on confirm-button.",
               "sourceRange": {
                 "start": {
                   "line": 105,
                   "column": 12
                 },
                 "end": {
-                  "line": 110,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "boolean | null | undefined"
-            },
-            {
-              "name": "confirm-text",
-              "description": "Text displayed on confirm-button.\nChanging sets confirm property to true.",
-              "sourceRange": {
-                "start": {
-                  "line": 115,
-                  "column": 12
-                },
-                "end": {
-                  "line": 118,
+                  "line": 108,
                   "column": 13
                 }
               },
@@ -580,14 +460,14 @@
             },
             {
               "name": "confirm-theme",
-              "description": "Theme for a confirm-button.\nChanging sets confirm property to true.",
+              "description": "Theme for a confirm-button.",
               "sourceRange": {
                 "start": {
-                  "line": 123,
+                  "line": 112,
                   "column": 12
                 },
                 "end": {
-                  "line": 126,
+                  "line": 115,
                   "column": 13
                 }
               },
@@ -599,11 +479,11 @@
               "description": "Whether to show cancel button or not.",
               "sourceRange": {
                 "start": {
-                  "line": 130,
+                  "line": 119,
                   "column": 12
                 },
                 "end": {
-                  "line": 135,
+                  "line": 124,
                   "column": 13
                 }
               },
@@ -612,14 +492,14 @@
             },
             {
               "name": "reject-text",
-              "description": "Text displayed on cancel-button.\nChanging sets cancel property to true.",
+              "description": "Text displayed on reject-button.\nShould also set `reject` property to true.",
               "sourceRange": {
                 "start": {
-                  "line": 140,
+                  "line": 129,
                   "column": 12
                 },
                 "end": {
-                  "line": 143,
+                  "line": 132,
                   "column": 13
                 }
               },
@@ -628,14 +508,14 @@
             },
             {
               "name": "reject-theme",
-              "description": "Theme for a cancel-button.\nChanging sets cancel property to true.",
+              "description": "Theme for a reject-button.\nShould also set `reject` property to true.",
               "sourceRange": {
                 "start": {
-                  "line": 148,
+                  "line": 137,
                   "column": 12
                 },
                 "end": {
-                  "line": 151,
+                  "line": 140,
                   "column": 13
                 }
               },
@@ -647,11 +527,11 @@
               "description": "Whether to show cancel button or not.",
               "sourceRange": {
                 "start": {
-                  "line": 155,
+                  "line": 144,
                   "column": 12
                 },
                 "end": {
-                  "line": 160,
+                  "line": 149,
                   "column": 13
                 }
               },
@@ -660,14 +540,14 @@
             },
             {
               "name": "cancel-text",
-              "description": "Text displayed on cancel-button.\nChanging sets cancel property to true.",
+              "description": "Text displayed on cancel-button.\nShould also set `cancel` property to true.",
               "sourceRange": {
                 "start": {
-                  "line": 165,
+                  "line": 154,
                   "column": 12
                 },
                 "end": {
-                  "line": 168,
+                  "line": 157,
                   "column": 13
                 }
               },
@@ -676,14 +556,14 @@
             },
             {
               "name": "cancel-theme",
-              "description": "Theme for a cancel-button.\nChanging sets cancel property to true.",
+              "description": "Theme for a cancel-button.\nShould also set `cancel` property to true.",
               "sourceRange": {
                 "start": {
-                  "line": 173,
+                  "line": 162,
                   "column": 12
                 },
                 "end": {
-                  "line": 176,
+                  "line": 165,
                   "column": 13
                 }
               },
@@ -714,12 +594,6 @@
               "type": "CustomEvent",
               "name": "opened-changed",
               "description": "Fired when the `opened` property changes.",
-              "metadata": {}
-            },
-            {
-              "type": "CustomEvent",
-              "name": "confirm-changed",
-              "description": "Fired when the `confirm` property changes.",
               "metadata": {}
             },
             {

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -45,7 +45,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             </vaadin-button>
           </slot>
           <slot name="confirm-button">
-            <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm" hidden$="[[!confirm]]">
+            <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm">
               [[confirmText]]
             </vaadin-button>
           </slot>
@@ -101,17 +101,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               type: String
             },
             /**
-             * Whether to show confirm button or not.
-             */
-            confirm: {
-              type: Boolean,
-              reflectToAttribute: true,
-              value: false,
-              notify: true
-            },
-            /**
              * Text displayed on confirm-button.
-             * Changing sets confirm property to true.
              */
             confirmText: {
               type: String,
@@ -119,7 +109,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
             /**
              * Theme for a confirm-button.
-             * Changing sets confirm property to true.
              */
             confirmTheme: {
               type: String,
@@ -135,16 +124,16 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               notify: true
             },
             /**
-             * Text displayed on cancel-button.
-             * Changing sets cancel property to true.
+             * Text displayed on reject-button.
+             * Should also set `reject` property to true.
              */
             rejectText: {
               type: String,
               value: 'Reject'
             },
             /**
-             * Theme for a cancel-button.
-             * Changing sets cancel property to true.
+             * Theme for a reject-button.
+             * Should also set `reject` property to true.
              */
             rejectTheme: {
               type: String,
@@ -161,7 +150,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
             /**
              * Text displayed on cancel-button.
-             * Changing sets cancel property to true.
+             * Should also set `cancel` property to true.
              */
             cancelText: {
               type: String,
@@ -169,21 +158,13 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
             /**
              * Theme for a cancel-button.
-             * Changing sets cancel property to true.
+             * Should also set `cancel` property to true.
              */
             cancelTheme: {
               type: String,
               value: 'tertiary'
             }
           };
-        }
-
-        static get observers() {
-          return [
-            '_confirmPropertyChanged(confirmText, confirmTheme)',
-            '_rejectPropertyChanged(rejectText, rejectTheme)',
-            '_cancelPropertyChanged(cancelText, cancelTheme)'
-          ];
         }
 
         ready() {
@@ -200,12 +181,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
-        _confirmPropertyChanged(confirmText, confirmTheme) {
-          if (confirmText !== 'Confirm' || confirmTheme !== 'primary') {
-            this.confirm = true;
-          }
-        }
-
         /**
          * @event confirm
          * fired when Confirm button was pressed.
@@ -215,12 +190,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           this.opened = false;
         }
 
-        _cancelPropertyChanged(cancelText, cancelTheme) {
-          if (cancelText !== 'Cancel' || cancelTheme !== 'tertiary') {
-            this.cancel = true;
-          }
-        }
-
         /**
          * @event cancel
          * fired when Cancel button or Escape key was pressed.
@@ -228,12 +197,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         _cancel() {
           this.dispatchEvent(new CustomEvent('cancel'));
           this.opened = false;
-        }
-
-        _rejectPropertyChanged(rejectText, rejectTheme) {
-          if (rejectText !== 'Reject' || rejectTheme !== 'error tertiary') {
-            this.reject = true;
-          }
         }
 
         /**

--- a/test/alert-api-test.html
+++ b/test/alert-api-test.html
@@ -47,9 +47,7 @@
 
       it('should be possible to set confirm button text', function() {
         var confirmButton = content.root.querySelector('#confirm');
-        expect(confirmButton.hidden).to.be.equal(true);
         confirm.confirmText = 'Of course';
-        expect(confirmButton.hidden).to.be.equal(false);
         var confirmButtonText = confirmButton.textContent;
         expect(confirmButtonText).to.contain('Of course');
       });


### PR DESCRIPTION
Change API so user should explicity set cancel/reject props to true in order to display the buttons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-confirm-dialog/13)
<!-- Reviewable:end -->
