### PR TITLE
Focus confirm button on dialog open

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: latest
+  firefox: "62.0.3"
   chrome: stable
 
 jobs:
@@ -20,12 +20,12 @@ jobs:
     - if: type = pull_request
       env: POLYMER=2
       addons:
-        firefox: latest
+        firefox: "62.0.3"
         chrome: stable
     - if: type = pull_request
       env: POLYMER=3
       addons:
-        firefox: latest
+        firefox: "62.0.3"
         chrome: stable
     - if: type = cron
       env: TEST_SUITE=unit_tests POLYMER=2

--- a/demo/confirm-dialog-basic-demos.html
+++ b/demo/confirm-dialog-basic-demos.html
@@ -154,8 +154,8 @@
       <template preserve-content>
         <vaadin-button id="open">Open dialog</vaadin-button>
         <vaadin-confirm-dialog cancel header="Unsaved changes">
-          <p>Do you want to <b>save</b> or <b>discard</b> your changes before navigating away?</p>
-          <vaadin-button id="save" slot="confirm-button" theme="primary">
+          <p id="description">Do you want to <b>save</b> or <b>discard</b> your changes before navigating away?</p>
+          <vaadin-button id="save" slot="confirm-button" theme="primary" aria-describedby="description">
             <iron-icon icon="vaadin:envelope-open" slot="prefix"></iron-icon>
             Save
           </vaadin-button>

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -33,7 +33,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           </slot>
         </div>
 
-        <div part="message">
+        <div part="message" id="message">
           <slot></slot>
           [[message]]
         </div>
@@ -41,21 +41,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         <div part="footer">
           <div class="cancel-button">
             <slot name="cancel-button">
-              <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]">
+              <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
                 [[cancelText]]
               </vaadin-button>
             </slot>
           </div>
           <div class="reject-button">
             <slot name="reject-button">
-              <vaadin-button id="reject" theme$="[[rejectTheme]]" on-click="_reject" hidden$="[[!reject]]">
+              <vaadin-button id="reject" theme$="[[rejectTheme]]" on-click="_reject" hidden$="[[!reject]]" aria-describedby="message">
                 [[rejectText]]
               </vaadin-button>
             </slot>
           </div>
           <div class="confirm-button">
             <slot name="confirm-button">
-              <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm">
+              <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm" aria-describedby="message">
                 [[confirmText]]
               </vaadin-button>
             </slot>

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -224,11 +224,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           });
 
           Polymer.RenderStatus.beforeNextRender(this, () => {
-            if (this._confirmButton) {
-              this._confirmButton.focus();
-            } else {
-              this.$.dialog.$.overlay.content.querySelector('#confirm').focus();
-            }
+            var confirmButton = this._confirmButton || this.$.dialog.$.overlay.content.querySelector('#confirm');
+            confirmButton.focus();
+            confirmButton.setAttribute('focus-ring', '');
           });
         }
 

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -62,7 +62,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           </div>
         </div>
       </template>
-      <slot></slot>
     </vaadin-dialog>
   </template>
 
@@ -200,6 +199,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             cancelTheme: {
               type: String,
               value: 'tertiary'
+            },
+            _confirmButton: {
+              type: Element
             }
           };
         }
@@ -213,7 +215,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           if (!this.opened) {
             return;
           }
-          Array.from(this.childNodes).forEach(c => this.$.dialog.$.overlay.$.content.appendChild(c));
+
+          Array.from(this.childNodes).forEach(c => {
+            var newChild = this.$.dialog.$.overlay.$.content.appendChild(c);
+            if (newChild.getAttribute && newChild.getAttribute('slot') == 'confirm-button' && newChild.focus) {
+              this._confirmButton = newChild;
+            }
+          });
+
+          Polymer.RenderStatus.beforeNextRender(this, () => {
+            if (this._confirmButton) {
+              this._confirmButton.focus();
+            } else {
+              this.$.dialog.$.overlay.content.querySelector('#confirm').focus();
+            }
+          });
         }
 
         _escPressed(event) {


### PR DESCRIPTION
Add aria-describedby attribute. This allows screenreaders to read the confirmation message in case when button is autofocused on dialog open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-confirm-dialog/59)
<!-- Reviewable:end -->
