### PR TITLE
Do not include the `lumo-dialog` style module

### DIFF
--- a/theme/lumo/vaadin-confirm-dialog-styles.html
+++ b/theme/lumo/vaadin-confirm-dialog-styles.html
@@ -5,7 +5,7 @@
 
 <dom-module id="lumo-confirm-dialog" theme-for="vaadin-confirm-dialog">
   <template>
-    <style include="lumo-dialog">
+    <style>
       [part="header"],
       .header {
         margin-top: var(--lumo-space-s);


### PR DESCRIPTION
The style module is already included by `<vaadin-dialog-overlay>`