### PR TITLE
Remove flex container and calculate content height (#88)

### DIFF
--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -20,18 +20,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         display: none;
         --_vaadin-confirm-dialog-content-width: auto;
         --_vaadin-confirm-dialog-content-height: auto;
-      }
-
-      [part="content"] {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        width: var(--_vaadin-confirm-dialog-content-width);
-        height: var(--_vaadin-confirm-dialog-content-height);
-      }
-
-      [part="message"] {
-        flex: 1 0 auto;
+        --_vaadin-confirm-dialog-footer-height: auto;
       }
     </style>
     <vaadin-dialog
@@ -41,7 +30,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       no-close-on-outside-click
       no-close-on-esc>
       <template>
-        <div part="content">
+        <div id="content">
           <div part="header">
             <slot name="header">
               <h3 class="header">[[header]]</h3>
@@ -52,29 +41,29 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             <slot></slot>
             [[message]]
           </div>
+        </div>
 
-          <div part="footer">
-            <div class="cancel-button">
-              <slot name="cancel-button">
-                <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
-                  [[cancelText]]
-                </vaadin-button>
-              </slot>
-            </div>
-            <div class="reject-button">
-              <slot name="reject-button">
-                <vaadin-button id="reject" theme$="[[rejectTheme]]" on-click="_reject" hidden$="[[!reject]]" aria-describedby="message">
-                  [[rejectText]]
-                </vaadin-button>
-              </slot>
-            </div>
-            <div class="confirm-button">
-              <slot name="confirm-button">
-                <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm" aria-describedby="message">
-                  [[confirmText]]
-                </vaadin-button>
-              </slot>
-            </div>
+        <div part="footer">
+          <div class="cancel-button">
+            <slot name="cancel-button">
+              <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
+                [[cancelText]]
+              </vaadin-button>
+            </slot>
+          </div>
+          <div class="reject-button">
+            <slot name="reject-button">
+              <vaadin-button id="reject" theme$="[[rejectTheme]]" on-click="_reject" hidden$="[[!reject]]" aria-describedby="message">
+                [[rejectText]]
+              </vaadin-button>
+            </slot>
+          </div>
+          <div class="confirm-button">
+            <slot name="confirm-button">
+              <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm" aria-describedby="message">
+                [[confirmText]]
+              </vaadin-button>
+            </slot>
           </div>
         </div>
       </template>
@@ -247,6 +236,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           Polymer.RenderStatus.beforeNextRender(this, () => {
             var confirmButton = this._confirmButton || this.$.dialog.$.overlay.content.querySelector('#confirm');
             confirmButton.focus();
+
+            const {height} = getComputedStyle(this.$.dialog.$.overlay.content.querySelector('[part=footer]'));
+            if (height != this._footerHeight) {
+              window.ShadyCSS.styleSubtree(this.$.dialog.$.overlay, {'--_vaadin-confirm-dialog-footer-height': height});
+              this._footerHeight = height;
+            }
           });
         }
 

--- a/test/resize-api-test.html
+++ b/test/resize-api-test.html
@@ -12,7 +12,7 @@
 <body>
   <test-fixture id="default">
     <template>
-      <vaadin-confirm-dialog opened>Confirmation message</vaadin-confirm-dialog>
+      <vaadin-confirm-dialog opened header="Title">Confirmation message</vaadin-confirm-dialog>
     </template>
   </test-fixture>
 
@@ -35,29 +35,38 @@
       }
 
       function getConfirmDialogContent(confirmDialog) {
-        return confirmDialog && confirmDialog.$.dialog.$.overlay.content.querySelector('[part="content"]');
+        return confirmDialog && confirmDialog.$.dialog.$.overlay.$.content;
+      }
+
+      function createConfirmDialog() {
+        const dialog = new window.Vaadin.ConfirmDialogElement();
+
+        dialog.header = 'Dialog title';
+        dialog.message = 'Dialog message';
+
+        return dialog;
       }
 
       it('should allow setting width', function(done) {
-        confirm._setWidth('500px');
+        confirm._setWidth('300px');
         waitForTransition(confirm, function() {
-          expect(getConfirmDialogContent(confirm).getBoundingClientRect().width).to.be.approximately(500, 2);
+          expect(getComputedStyle(getConfirmDialogContent(confirm)).width).to.be.equal('300px');
           done();
         });
       });
 
       it('Should not throw exception if _setWidth is called before attach', function(done) {
-        const confirmNotAttached = new window.Vaadin.ConfirmDialogElement();
+        const confirmNotAttached = createConfirmDialog();
         const spy = sinon.spy(confirmNotAttached, '_setDimension');
 
-        confirmNotAttached._setWidth('150px');
+        confirmNotAttached._setWidth('200px');
         document.body.appendChild(confirmNotAttached);
         confirmNotAttached.opened = true;
 
-        expect(spy.calledWith('width', '150px')).to.be.true;
+        expect(spy.calledWith('width', '200px')).to.be.true;
 
         waitForTransition(confirmNotAttached, function() {
-          expect(getConfirmDialogContent(confirmNotAttached).getBoundingClientRect().width).to.approximately(150, 2);
+          expect(getComputedStyle(getConfirmDialogContent(confirmNotAttached)).width).to.be.equal('200px');
           done();
         });
       });
@@ -65,23 +74,23 @@
       it('should allow setting height', function(done) {
         confirm._setHeight('500px');
         waitForTransition(confirm, function() {
-          expect(getConfirmDialogContent(confirm).getBoundingClientRect().height).to.be.approximately(500, 2);
+          expect(getComputedStyle(getConfirmDialogContent(confirm)).height).to.be.equal('500px');
           done();
         });
       });
 
       it('Should not throw exception if _setHeight is called before attach', function(done) {
-        const confirmNotAttached = new window.Vaadin.ConfirmDialogElement();
+        const confirmNotAttached = createConfirmDialog();
         const spy = sinon.spy(confirmNotAttached, '_setDimension');
 
-        confirmNotAttached._setHeight('150px');
+        confirmNotAttached._setHeight('200px');
         document.body.appendChild(confirmNotAttached);
         confirmNotAttached.opened = true;
 
-        expect(spy.calledWith('height', '150px')).to.be.true;
+        expect(spy.calledWith('height', '200px')).to.be.true;
 
         waitForTransition(confirmNotAttached, function() {
-          expect(getConfirmDialogContent(confirmNotAttached).getBoundingClientRect().height).to.be.approximately(150, 2);
+          expect(getComputedStyle(getConfirmDialogContent(confirmNotAttached)).height).to.be.equal('200px');
           done();
         });
       });

--- a/test/visual/custom-buttons.html
+++ b/test/visual/custom-buttons.html
@@ -24,7 +24,7 @@
 <body style="height: 600px">
   <vaadin-confirm-dialog cancel opened>
     <h2 slot="header">Unsaved changes</h2>
-    <p id="description" style="margin: 0;">Do you want to <b>save</b> or <b>discard</b> your changes before navigating away?</p>
+    <p id="description">Do you want to <b>save</b> or <b>discard</b> your changes before navigating away?</p>
     <vaadin-button id="save" slot="confirm-button" theme="primary" aria-describedby="description">
       <iron-icon icon="vaadin:envelope-open" slot="prefix"></iron-icon>
       Save

--- a/theme/lumo/vaadin-confirm-dialog-styles.html
+++ b/theme/lumo/vaadin-confirm-dialog-styles.html
@@ -6,6 +6,12 @@
 <dom-module id="lumo-confirm-dialog" theme-for="vaadin-confirm-dialog">
   <template>
     <style>
+      #content {
+        height: calc(var(--_vaadin-confirm-dialog-content-height) - var(--_vaadin-confirm-dialog-footer-height) - var(--lumo-space-s));
+        width: var(--_vaadin-confirm-dialog-content-width);
+      }
+
+      [part="header"],
       .header {
         margin-top: var(--lumo-space-s);
         margin-bottom: var(--lumo-space-m);

--- a/theme/material/vaadin-confirm-dialog-styles.html
+++ b/theme/material/vaadin-confirm-dialog-styles.html
@@ -1,6 +1,11 @@
 <dom-module id="material-confirm-dialog" theme-for="vaadin-confirm-dialog">
   <template>
     <style>
+      #content {
+        height: calc(var(--_vaadin-confirm-dialog-content-height) - var(--_vaadin-confirm-dialog-footer-height) - 39px);
+        width: var(--_vaadin-confirm-dialog-content-width);
+      }
+
       [part="message"] {
         width: 25em;
         max-width: 100%;


### PR DESCRIPTION
- Move `[part=footer]` outside of `[part=content]`
- Calculate `[part=footer]` height to calculate `[part=content]` height
- Remove flex related styles

cherry picked from master (#88 & #89)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-confirm-dialog/90)
<!-- Reviewable:end -->
