### PR TITLE
Propagate theme property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.4.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0",

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -27,6 +27,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       id="dialog"
       opened="{{opened}}"
       aria-label="[[_getAriaLabel(header)]]"
+      theme="[[theme]]"
       no-close-on-outside-click
       no-close-on-esc="[[noCloseOnEsc]]">
       <template>
@@ -212,6 +213,10 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               type: String,
               value: 'tertiary'
             },
+            /**
+             * Theme to apply to the overlay element
+             */
+            theme: String,
             _confirmButton: {
               type: Element
             }

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -27,7 +27,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       id="dialog"
       opened="{{opened}}"
       aria-label="[[_getAriaLabel(header)]]"
-      theme="[[theme]]"
+      theme$="[[theme]]"
       no-close-on-outside-click
       no-close-on-esc="[[noCloseOnEsc]]">
       <template>
@@ -212,13 +212,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             cancelTheme: {
               type: String,
               value: 'tertiary'
-            },
-            /**
-             * Theme to apply to the overlay element
-             */
-            theme: String,
-            _confirmButton: {
-              type: Element
             }
           };
         }

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -212,6 +212,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             cancelTheme: {
               type: String,
               value: 'tertiary'
+            },
+            _confirmButton: {
+              type: Element
             }
           };
         }

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -3,5 +3,6 @@ window.VaadinConfirmDialogSuites = [
   'cancel-api-test.html',
   'confirmation-api-test.html',
   'confirm-reject-api-test.html',
-  'resize-api-test.html'
+  'resize-api-test.html',
+  'theme-propagation-api-test.html'
 ];

--- a/test/theme-propagation-api-test.html
+++ b/test/theme-propagation-api-test.html
@@ -19,10 +19,13 @@
   <script>
     describe('theme attribute', () => {
       let confirmDialog;
+
       beforeEach(() => confirmDialog = fixture('confirm-dialog-theme'));
+
       it('should propagate theme attribute to vaadin-dialog', () => {
         expect(confirmDialog.$.dialog.getAttribute('theme')).to.equal('foo');
       });
+
       it('should propagate theme attribute to overlay', () => {
         expect(confirmDialog.$.dialog.$.overlay.getAttribute('theme')).to.equal('foo');
       });

--- a/test/theme-propagation-api-test.html
+++ b/test/theme-propagation-api-test.html
@@ -1,0 +1,31 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-confirm-dialog tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../vaadin-confirm-dialog.html">
+</head>
+
+<body>
+  <test-fixture id="confirm-dialog-theme">
+    <template>
+      <vaadin-confirm-dialog theme="foo"></vaadin-confirm-dialog>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('theme attribute', () => {
+      let confirmDialog;
+      beforeEach(() => confirmDialog = fixture('confirm-dialog-theme'));
+      it('should propagate theme attribute to vaadin-dialog', () => {
+        expect(confirmDialog.$.dialog.getAttribute('theme')).to.equal('foo');
+      });
+      it('should propagate theme attribute to overlay', () => {
+        expect(confirmDialog.$.dialog.$.overlay.getAttribute('theme')).to.equal('foo');
+      });
+    });
+  </script>
+</body>


### PR DESCRIPTION
Propagate `theme` property to `vaadin-dialog`, which in turn propagates it to the overlay. See https://github.com/vaadin/vaadin-confirm-dialog-flow/issues/38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-confirm-dialog/92)
<!-- Reviewable:end -->
