### PR TITLE
refactor: only run license checker when needed

### DIFF
--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -211,6 +211,19 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           };
         }
 
+        /**
+         * @protected
+         */
+        static _finalizeClass() {
+          super._finalizeClass();
+
+          const devModeCallback = window.Vaadin.developmentModeCallback;
+          const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
+          if (typeof licenseChecker === 'function') {
+            licenseChecker(ConfirmDialogElement);
+          }
+        }
+
         ready() {
           super.ready();
           this.$.dialog.$.overlay.addEventListener('vaadin-overlay-escape-press', this._escPressed.bind(this));
@@ -322,12 +335,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        * @namespace Vaadin
        */
       window.Vaadin.ConfirmDialogElement = ConfirmDialogElement;
-
-      const licenseChecker = window.Vaadin.developmentModeCallback
-        && window.Vaadin.developmentModeCallback['vaadin-license-checker'];
-      if (typeof licenseChecker === 'function') {
-        licenseChecker(ConfirmDialogElement);
-      }
     })();
   </script>
 </dom-module>


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#492

This PR makes sure the license checker is only called when the component is created.
The static `_finalizeClass` method is needed to ensure we call it [once per class](https://github.com/Polymer/polymer/blob/f6ccc9d1bdc81e934e21bf27b3dba517b5840fd4/lib/mixins/properties-mixin.js#L138-L147).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-confirm-dialog/93)
<!-- Reviewable:end -->
