### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,20 +26,20 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.2",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.0",
     "vaadin-license-checker": "vaadin/license-checker#^2.1.0",
-    "vaadin-dialog": "vaadin/vaadin-dialog#^2.4.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.3.0",
-    "vaadin-overlay": "vaadin/vaadin-overlay#^3.4.0"
+    "vaadin-dialog": "vaadin/vaadin-dialog#^2.5.0-alpha1",
+    "vaadin-button": "vaadin/vaadin-button#^2.4.0-alpha1",
+    "vaadin-overlay": "vaadin/vaadin-overlay#^3.5.0"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
-    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0-alpha1",
+    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0",
     "vaadin-icons": "vaadin/vaadin-icons#^4.2.0",
     "iron-test-helpers": "^2.0.0"
   }

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,9 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ]
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-confirm-dialog.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
     "src",
     "theme"

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -126,6 +126,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           return {
             /**
              * True if the overlay is currently displayed.
+             * @type {boolean}
              */
             opened: {
               type: Boolean,
@@ -133,42 +134,53 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               notify: true,
               observer: '_openedChanged'
             },
+
             /**
              * Set the confirmation dialog title.
+             * @type {string}
              */
             header: {
               type: String,
               value: ''
             },
+
             /**
              * Set the message or confirmation question.
              */
             message: {
               type: String
             },
+
             /**
              * Text displayed on confirm-button.
+             * @type {string}
              */
             confirmText: {
               type: String,
               value: 'Confirm'
             },
+
             /**
              * Theme for a confirm-button.
+             * @type {string}
              */
             confirmTheme: {
               type: String,
               value: 'primary'
             },
+
             /**
              * Set to true to disable closing dialog on Escape press
+             * @type {boolean}
              */
             noCloseOnEsc: {
               type: Boolean,
               value: false
             },
+
             /**
              * Whether to show cancel button or not.
+             * @type {boolean}
              */
             reject: {
               type: Boolean,
@@ -176,22 +188,28 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               value: false,
               notify: true
             },
+
             /**
              * Text displayed on reject-button.
+             * @type {string}
              */
             rejectText: {
               type: String,
               value: 'Reject'
             },
+
             /**
              * Theme for a reject-button.
+             * @type {string}
              */
             rejectTheme: {
               type: String,
               value: 'error tertiary'
             },
+
             /**
              * Whether to show cancel button or not.
+             * @type {boolean}
              */
             cancel: {
               type: Boolean,
@@ -199,29 +217,33 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               value: false,
               notify: true
             },
+
             /**
              * Text displayed on cancel-button.
+             * @type {string}
              */
             cancelText: {
               type: String,
               value: 'Cancel'
             },
+
             /**
              * Theme for a cancel-button.
+             * @type {string}
              */
             cancelTheme: {
               type: String,
               value: 'tertiary'
             },
+
+            /** @private */
             _confirmButton: {
               type: Element
             }
           };
         }
 
-        /**
-         * @protected
-         */
+        /** @protected */
         static _finalizeClass() {
           super._finalizeClass();
 
@@ -232,6 +254,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
+        /** @protected */
         ready() {
           super.ready();
           this.$.dialog.$.overlay.addEventListener('vaadin-overlay-escape-press', this._escPressed.bind(this));
@@ -242,6 +265,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
+        /**
+         * @param {string} name
+         * @param {?string} oldValue
+         * @param {?string} newValue
+         * @protected
+         */
         attributeChangedCallback(name, oldValue, newValue) {
           super.attributeChangedCallback(name, oldValue, newValue);
           if (name === 'dir') {
@@ -251,6 +280,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
+        /** @private */
         __toggleContentRTL(rtl) {
           const contentBlock = this.$.dialog.$.overlay.content.querySelector('#content');
           const footerBlock = this.$.dialog.$.overlay.content.querySelector('[part=footer]');
@@ -263,6 +293,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
+        /** @private */
         _openedChanged() {
           if (!this.opened) {
             return;
@@ -289,51 +320,47 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           });
         }
 
+        /** @private */
         _escPressed(event) {
           if (!event.defaultPrevented) {
             this._cancel();
           }
         }
 
-        /**
-         * @event confirm
-         * fired when Confirm button was pressed.
-         */
+        /** @private */
         _confirm() {
           this.dispatchEvent(new CustomEvent('confirm'));
           this.opened = false;
         }
 
-        /**
-         * @event cancel
-         * fired when Cancel button or Escape key was pressed.
-         */
+        /** @private */
         _cancel() {
           this.dispatchEvent(new CustomEvent('cancel'));
           this.opened = false;
         }
 
-        /**
-         * @event reject
-         * fired when Reject button was pressed.
-         */
+        /** @private */
         _reject() {
           this.dispatchEvent(new CustomEvent('reject'));
           this.opened = false;
         }
 
+        /** @private */
         _getAriaLabel(header) {
           return header || 'confirmation';
         }
 
+        /** @private */
         _setWidth(width) {
           this._setDimensionIfAttached('width', width);
         }
 
+        /** @private */
         _setHeight(height) {
           this._setDimensionIfAttached('height', height);
         }
 
+        /** @private */
         _setDimensionIfAttached(name, value) {
           if (this.$ && this.$.dialog) {
             this._setDimension(name, value);
@@ -343,6 +370,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
         }
 
+        /** @private */
         _setDimension(name, value) {
           this._propsToUpdate = this._propsToUpdate || {};
 
@@ -356,6 +384,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             }
           });
         }
+
+        /**
+         * @event confirm
+         * fired when Confirm button was pressed.
+         */
+
+        /**
+         * @event cancel
+         * fired when Cancel button or Escape key was pressed.
+         */
+
+        /**
+         * @event reject
+         * fired when Reject button was pressed.
+         */
       }
 
       customElements.define(ConfirmDialogElement.is, ConfirmDialogElement);


### PR DESCRIPTION
Fixes #101 

Generated TS definitions look like this:

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {beforeNextRender} from '@polymer/polymer/lib/utils/render-status.js';

declare class ConfirmDialogElement extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {
  opened: boolean;
  header: string;
  message: string|null|undefined;
  confirmText: string;
  confirmTheme: string;
  noCloseOnEsc: boolean;
  reject: boolean;
  rejectText: string;
  rejectTheme: string;
  cancel: boolean;
  cancelText: string;
  cancelTheme: string;
  static _finalizeClass(): void;
  ready(): void;
  attributeChangedCallback(name: string, oldValue: string|null, newValue: string|null): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-confirm-dialog": ConfirmDialogElement;
  }
}

export {ConfirmDialogElement};
```