### PR TITLE
fix: scope vaadin-dialog styles under theme

### DIFF
--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -27,7 +27,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       id="dialog"
       opened="{{opened}}"
       aria-label="[[_getAriaLabel(header)]]"
-      theme$="vaadin-confirm-dialog-theme [[theme]]"
+      theme$="_vaadin-confirm-dialog-dialog-overlay-theme [[theme]]"
       no-close-on-outside-click
       no-close-on-esc="[[noCloseOnEsc]]">
       <template>

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -27,7 +27,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       id="dialog"
       opened="{{opened}}"
       aria-label="[[_getAriaLabel(header)]]"
-      theme$="[[theme]]"
+      theme$="vaadin-confirm-dialog-theme [[theme]]"
       no-close-on-outside-click
       no-close-on-esc="[[noCloseOnEsc]]">
       <template>

--- a/test/theme-propagation-api-test.html
+++ b/test/theme-propagation-api-test.html
@@ -23,11 +23,13 @@
       beforeEach(() => confirmDialog = fixture('confirm-dialog-theme'));
 
       it('should propagate theme attribute to vaadin-dialog', () => {
-        expect(confirmDialog.$.dialog.getAttribute('theme')).to.equal('foo');
+        const themes = confirmDialog.$.dialog.getAttribute('theme').split(' ');
+        expect(themes).to.include.members(['foo']);
       });
 
       it('should propagate theme attribute to overlay', () => {
-        expect(confirmDialog.$.dialog.$.overlay.getAttribute('theme')).to.equal('foo');
+        const themes = confirmDialog.$.dialog.$.overlay.getAttribute('theme').split(' ');
+        expect(themes).to.include.members(['foo']);
       });
     });
   </script>

--- a/theme/lumo/vaadin-confirm-dialog-styles.html
+++ b/theme/lumo/vaadin-confirm-dialog-styles.html
@@ -6,7 +6,7 @@
 <dom-module id="lumo-confirm-dialog-overlay" theme-for="vaadin-dialog-overlay">
   <template>
     <style>
-      :host([theme~="vaadin-confirm-dialog-theme"]) #content {
+      :host([theme~="_vaadin-confirm-dialog-dialog-overlay-theme"]) [part="content"] {
         height: auto;
         box-sizing: content-box;
       }

--- a/theme/lumo/vaadin-confirm-dialog-styles.html
+++ b/theme/lumo/vaadin-confirm-dialog-styles.html
@@ -6,7 +6,7 @@
 <dom-module id="lumo-confirm-dialog-overlay" theme-for="vaadin-dialog-overlay">
   <template>
     <style>
-      #content {
+      :host([theme~="vaadin-confirm-dialog-theme"]) #content {
         height: auto;
         box-sizing: content-box;
       }

--- a/theme/material/vaadin-confirm-dialog-styles.html
+++ b/theme/material/vaadin-confirm-dialog-styles.html
@@ -73,12 +73,12 @@
 <dom-module id="material-confirm-dialog-overlay" theme-for="vaadin-dialog-overlay">
   <template>
     <style include="material-vaadin-overlay">
-      [part="overlay"] {
+      :host([theme~="vaadin-confirm-dialog-theme"]) [part="overlay"] {
         max-width: 100%;
         min-width: 0;
       }
 
-      [part="content"] {
+      :host([theme~="vaadin-confirm-dialog-theme"]) [part="content"] {
         padding: 8px 24px;
         min-width: 0;
         height: auto;

--- a/theme/material/vaadin-confirm-dialog-styles.html
+++ b/theme/material/vaadin-confirm-dialog-styles.html
@@ -73,12 +73,12 @@
 <dom-module id="material-confirm-dialog-overlay" theme-for="vaadin-dialog-overlay">
   <template>
     <style include="material-vaadin-overlay">
-      :host([theme~="vaadin-confirm-dialog-theme"]) [part="overlay"] {
+      :host([theme~="_vaadin-confirm-dialog-dialog-overlay-theme"]) [part="overlay"] {
         max-width: 100%;
         min-width: 0;
       }
 
-      :host([theme~="vaadin-confirm-dialog-theme"]) [part="content"] {
+      :host([theme~="_vaadin-confirm-dialog-dialog-overlay-theme"]) [part="content"] {
         padding: 8px 24px;
         min-width: 0;
         height: auto;


### PR DESCRIPTION
Create a internal theme for `vaadin-dialog`, so it won't affect other `vaadin-dialog` in an application.

Fix vaadin/vaadin-dialog#178